### PR TITLE
Add `supports` to `acf_register_block()`

### DIFF
--- a/src/ACF/Blocks/Block.php
+++ b/src/ACF/Blocks/Block.php
@@ -132,6 +132,17 @@ class Block
 
         return $this;
     }
+    
+    /**
+     * @param array $supports
+     * @return Block
+     */
+    public function setSupports(Array $supports): self
+    {
+        $this->supports = $supports;
+
+        return $this;
+    }
 
     /**
      *
@@ -148,7 +159,8 @@ class Block
                 'category' => $this->catSlug,
                 'icon' => $this->blockIcon,
                 'keywords' => $this->blockKeywords,
-                'post_types' => $this->postTypes
+                'post_types' => $this->postTypes,
+                'supports' => $this->supports
             ]);
         }
     }

--- a/src/ACF/Blocks/Block.php
+++ b/src/ACF/Blocks/Block.php
@@ -52,6 +52,11 @@ class Block
      * @var
      */
     public $postTypes = ['post', 'page'];
+    
+    /**
+     * @var
+     */
+    public $supports = ['align' => false];
 
     /**
      * Block constructor.
@@ -139,7 +144,7 @@ class Block
      */
     public function setSupports(Array $supports): self
     {
-        $this->supports = $supports;
+        $this->supports = array_merge($this->supports, $supports);
 
         return $this;
     }


### PR DESCRIPTION
Allows `supports` from Block Registration

see - https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-registration/

example - will remove alignment from block
```
public function registerBlock(): void
{
    $this->setBlockName('hero-banner')
        ->setBlockTitle('Hero banner')
        ->setBlockCallback([__CLASS__, 'renderBlock'])
        ->setBlockIcon('cover-image')
        ->setCat('common')
        ->setSupports([
            'align' => false
        ])
        ->saveBlock();
}
```