### PR TITLE
Move some packages to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
     }
   ],
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.2"
+  },
+  "require-dev": {
     "squizlabs/php_codesniffer": "^3.3",
     "exussum12/coverage-checker": "^0.11.0"
   },


### PR DESCRIPTION
Only install `coverage-checker` and `codesniffer` in development environments